### PR TITLE
add legacy vtk correction

### DIFF
--- a/trimeshpy/vtk_util.py
+++ b/trimeshpy/vtk_util.py
@@ -149,7 +149,7 @@ def save_polydata(polydata, file_name, binary=False, color_array_name=None, lega
     writer = set_input(writer, polydata)
     if color_array_name is not None:
         writer.SetArrayName(color_array_name)
-    if legacy_vtk_format:
+    if legacy_vtk_format and file_extension in ["vtk", "vtp", "fib"]:
         writer.SetFileVersion(42)
     if binary:
         writer.SetFileTypeToBinary()


### PR DESCRIPTION
I've added a correction to an error I hadn't seen at first. The vtk_legacy option applied to files not in vtkPolyDataWritter.
sorry for this lack of vigilance